### PR TITLE
fix: fix basil_tonic build failed on macos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ user.bazelrc
 compile_flags.txt
 compile_commands.json
 rust-project.json
+.cache

--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "a96ef8084647264ce42079a8a2e1495e40d1c3152e317323e3a6bc142e1d012b",
+  "checksum": "00f4183a066839e07cab80d6d361fd6e4c63ee90cdfa5da5134f6b377fcbdd61",
   "crates": {
     "addr2line 0.21.0": {
       "name": "addr2line",
@@ -1329,6 +1329,10 @@
             {
               "id": "futures-util 0.3.28",
               "target": "futures_util"
+            },
+            {
+              "id": "libc 0.2.147",
+              "target": "libc"
             },
             {
               "id": "prost 0.11.9",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,6 +250,7 @@ version = "0.0.1"
 dependencies = [
  "clap",
  "futures-util",
+ "libc",
  "prost",
  "prost-types",
  "protoc-gen-prost",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -165,6 +165,7 @@ crates_repository(
             version = "0.3",
         ),
         "url": crate.spec(version = "2.4"),
+        "libc": crate.spec(version = "0.2.147")
     },
 )
 

--- a/basil_tonic/BUILD
+++ b/basil_tonic/BUILD
@@ -24,6 +24,7 @@ rust_library(
         "@crate_index//:tonic",
         "@crate_index//:tracing",
         "@crate_index//:url",
+        "@crate_index//:libc",
     ],
 )
 


### PR DESCRIPTION
I wan't to use repo in macos, but i found the basil_tonic build is failed, this PR fixed the build on macos m1 architecture.