### PR TITLE
Maintain set of visited dependency set ids

### DIFF
--- a/bcc/dep_set_of_files.cpp
+++ b/bcc/dep_set_of_files.cpp
@@ -26,6 +26,7 @@ dep_set_of_files::get(std::uint32_t id) const
     return dep_set(it->second);
   }
   std::vector<std::string> result;
+  std::set<uint32_t> visited_ids;
 
   std::queue<entry> q;
 
@@ -35,6 +36,9 @@ dep_set_of_files::get(std::uint32_t id) const
     result.push_back(artifacts_.path_of_artifact(k));
   }
   for (auto const& k : it->second.transitive) {
+    if (!visited_ids.insert(k).second) {
+      continue;
+    }
     auto const j = table_.find(k);
     assert(j != table_.end());
     q.push(j->second);
@@ -46,6 +50,9 @@ dep_set_of_files::get(std::uint32_t id) const
       result.push_back(artifacts_.path_of_artifact(k));
     }
     for (auto const& k : front.transitive) {
+      if (!visited_ids.insert(k).second) {
+        continue;
+      }
       auto const j = table_.find(k);
       assert(j != table_.end());
       q.push(j->second);

--- a/bcc/dep_set_of_files.cpp
+++ b/bcc/dep_set_of_files.cpp
@@ -26,7 +26,7 @@ dep_set_of_files::get(std::uint32_t id) const
     return dep_set(it->second);
   }
   std::vector<std::string> result;
-  std::set<uint32_t> visited_ids;
+  std::set<std::uint32_t> visited_ids;
 
   std::queue<entry> q;
 


### PR DESCRIPTION
Without this, each call to dep_set_of_files::get() takes multiple seconds in my project due to needing to repeatedly visit parts of a large DAG of dependencies.

For some reason, this only started happening after upgrading the project to Bazel 8.