### PR TITLE
Update module `rules_cc` to version `0.1.1`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -17,7 +17,7 @@ bazel_dep(name = "googletest", version = "1.15.2", repo_name = "com_google_googl
 bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "protobuf", version = "29.2", repo_name = "com_google_protobuf")
 bazel_dep(name = "rules_apple", version = "3.16.0", repo_name = "build_bazel_rules_apple")
-bazel_dep(name = "rules_cc", version = "0.1.0")
+bazel_dep(name = "rules_cc", version = "0.1.1")
 bazel_dep(name = "rules_java", version = "8.6.2")
 bazel_dep(name = "rules_pkg", version = "1.0.1")
 bazel_dep(name = "rules_python", version = "1.0.0")


### PR DESCRIPTION
Thanks for this amazing tool! Just wanted to share my small tweak:

Version `0.1.0` is yanked: https://registry.bazel.build/modules/rules_cc
This hits errors when doing `bazel build --config=gnu //bcc:bazel-compile-commands`:
```bash
ERROR: Error computing the main repository mapping: Yanked version detected in your resolved dependency graph: rules_cc@0.1.0, for the reason: rules_cc 0.1.0 is yanked due to incompatible change (prematurely removing cc_proto_library from defs.bzl), please upgrade to 0.1.1.
Yanked versions may contain serious vulnerabilities and should not be used. To fix this, use a bazel_dep on a newer version of this module. To continue using this version, allow it using the --allow_yanked_versions flag or the BZLMOD_ALLOW_YANKED_VERSIONS env variable.
```
This can be fixed by updating the version of the module to `0.1.1`.
