### PR TITLE
Add cross-compilation support using LLVM toolchain

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -55,22 +55,30 @@ jobs:
 
     strategy:
       matrix:
-        build:
-          - jammy
-          - noble
-          - macos-universal
-          # - windows
         include:
-          - build: jammy
+          - build: jammy-x86_64
             os: ubuntu-22.04
             config: gnu
+            platform: "//:linux_x86_64"
             pkgfile: bazel-compile-commands_${{ github.event.inputs.version || 0 }}-jammy_amd64.deb
-          - build: noble
+          - build: noble-x86_64
             os: ubuntu-24.04
             config: gnu
+            platform: "//:linux_x86_64"
             pkgfile: bazel-compile-commands_${{ github.event.inputs.version || 0 }}-noble_amd64.deb
+          - build: jammy-aarch64
+            os: ubuntu-22.04
+            config: gnu
+            platform: "@toolchains_llvm//platforms:linux-aarch64"
+            pkgfile: bazel-compile-commands_${{ github.event.inputs.version || 0 }}-jammy_arm64.deb
+          - build: noble-arm64
+            os: ubuntu-24.04
+            config: gnu
+            platform: "@toolchains_llvm//platforms:linux-aarch64"
+            pkgfile: bazel-compile-commands_${{ github.event.inputs.version || 0 }}-noble_arm64.deb
           - build: macos-universal
             os: macos-latest
+            platform: "//:apple-darwin-aarch64"
             config: gnu
             pkgfile: bazel-compile-commands_${{ github.event.inputs.version || 0 }}-macos_universal.zip
           # - build: windows
@@ -90,12 +98,14 @@ jobs:
           restore-keys: |
             ${{ matrix.os }}-bazel-buildpkg-
       - name: Build Release Package
-        run: >
-          bazel run
-          --config=${{ matrix.config }}
-          --config=ci --config=release
-          --//:version=${{ github.event.inputs.version || 0 }}
-          --disk_cache=~/.cache/bazel_build_cache
+        run: |
+          bazel run \
+          --extra_toolchains=@llvm_toolchain//:all \
+          --platforms "${{ matrix.platform }}" \
+          --config=${{ matrix.config }} \
+          --config=ci --config=release \
+          --//:version=${{ github.event.inputs.version || 0 }} \
+          --disk_cache=~/.cache/bazel_build_cache \
           //:copy -- ${{ matrix.pkgfile }}
       - name: Upload package artifact
         uses: actions/upload-artifact@v4
@@ -125,10 +135,10 @@ jobs:
       - name: Download pkg artifact
         uses: actions/download-artifact@v4
         with:
-          pattern: pkg-bazel-noble
+          pattern: pkg-bazel-noble-x86_64
       - name: Install
         run: |
-          sudo dpkg --install pkg-bazel-noble/bazel-compile-commands_*.deb
+          sudo dpkg --install pkg-bazel-noble-x86_64/bazel-compile-commands_*.deb
       - name: Create compile-commands.json
         run: |
           /usr/bin/bazel-compile-commands -v -a --config=gnu --replace=-fno-canonical-system-headers= //...

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -6,25 +6,33 @@ load("//bazel:pkg_info.bzl", "pkg_variables", "pkg_version")
 package(default_visibility = ["//visibility:public"])
 
 platform(
-    name = "arm64-apple-darwin",
+    name = "apple-darwin-aarch64",
     constraint_values = [
-        "@platforms//cpu:arm64",
+        "@platforms//cpu:aarch64",
         "@platforms//os:macos",
     ],
 )
 
 platform(
-    name = "x86_64-apple-darwin",
+    name = "apple-darwin-x86_64",
     constraint_values = [
         "@platforms//cpu:x86_64",
         "@platforms//os:macos",
     ],
 )
 
+platform(
+    name = "linux_x86_64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
 filegroup(
     name = "pandoc_macos",
     srcs = select({
-        "@platforms//cpu:arm64": ["@pandoc_macos_arm64//:pandoc"],
+        "@platforms//cpu:aarch64": ["@pandoc_macos_aarch64//:pandoc"],
         "@platforms//cpu:x86_64": ["@pandoc_macos_x86_64//:pandoc"],
     }),
 )
@@ -123,7 +131,7 @@ pkg_variables(
     name = "variables",
     architecture = select({
         "@platforms//cpu:x86_64": "amd64",
-        "@platforms//cpu:arm64": "arm64",
+        "@platforms//cpu:aarch64": "arm64",
     }),
     os = select({
         "@platforms//os:linux": "linux",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -19,6 +19,7 @@ bazel_dep(name = "rules_cc", version = "0.1.1")
 bazel_dep(name = "rules_java", version = "8.11.0")
 bazel_dep(name = "rules_pkg", version = "1.1.0")
 bazel_dep(name = "rules_python", version = "1.3.0")
+bazel_dep(name = "toolchains_llvm", version = "1.4.0")
 
 bazel_dep(name = "googletest", version = "1.16.0", dev_dependency = True, repo_name = "com_google_googletest")
 
@@ -27,6 +28,19 @@ apple_cc_configure = use_extension(
     "apple_cc_configure_extension",
 )
 use_repo(apple_cc_configure, "local_config_apple_cc")
+
+# Configure the toolchain, but do not register it by default.
+# Otherwise, it will be used also for e.g. clang-format.
+llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")
+llvm.toolchain(
+   llvm_version = "20.1.2",
+   stdlib = {"linux-aarch64": "stdc++"}
+)
+llvm.sysroot(
+    label = "@sysroot_linux_aarch64//:sysroot",
+    targets = ["linux-aarch64"],
+)
+use_repo(llvm, "llvm_toolchain")
 
 http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
@@ -56,7 +70,7 @@ http_archive(
 )
 
 http_archive(
-    name = "pandoc_macos_arm64",
+    name = "pandoc_macos_aarch64",
     build_file = "//bazel:pandoc.BUILD",
     integrity = "sha256-eP7a5CZoLym9PA2uUfdyWXOvvAEVM7NYAmVw6lkPx4U=",
     strip_prefix = "pandoc-3.6-arm64",
@@ -69,4 +83,18 @@ http_archive(
     integrity = "sha256-BnMre5bTuZ9xG6G/JPKJ/LW8lWEZK9wb2VFMF8iqLCA=",
     strip_prefix = "pandoc-3.6",
     urls = ["https://github.com/jgm/pandoc/releases/download/3.6/pandoc-3.6-windows-x86_64.zip"],
+)
+
+# Sysroot for cross-compilation
+http_archive(
+    name = "sysroot_linux_aarch64",
+    build_file_content = """
+filegroup(
+  name = "sysroot",
+  srcs = glob(["*/**"]),
+  visibility = ["//visibility:public"],
+)
+""",
+    sha256 = "8462b3c1bbb7d6e6b5ec48e3b64d59671155b0a522a28e3bcabef67bced3e008",
+    urls = ["https://github.com/scasagrande/toolchains_llvm_sysroot/releases/download/linux-sysroot-4_18-2_28-10_3_0/linux-sysroot-aarch64.tar.zst"],
 )

--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ to integrate`bazel-compile-commands` into VS Code.
 bazel build --config=gnu //bcc:bazel-compile-commands
 ```
 
+To cross-compiling for a Linux `aarch64` platform, run:
+
+```sh
+bazel build --extra_toolchains=@llvm_toolchain//:all --platforms=@toolchains_llvm//platforms:linux-aarch64 --config=gnu //bcc:bazel-compile-commands
+```
+
 ### Windows
 
 ```sh


### PR DESCRIPTION
Using bazel-compile-commands on development containers for `aarch64` would be quite cool. Hence, I added support for building for `aarch64` using a simple cross-building-toolchain. I also added support for building the Debian packages in GHA.

Also: added a devcontainer for convenience. If that is not wanted, it can be removed again.

Closes https://github.com/eclipse-score/devcontainer/issues/25