### PR TITLE
Set directory to workspace rather than execution root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ user.bazelrc
 .bazelccrc
 compile_flags.txt
 compile_commands.json
+external
 rust-project.json

--- a/bcc/bazel.cpp
+++ b/bcc/bazel.cpp
@@ -78,12 +78,13 @@ bazel::create(std::filesystem::path const& bazel_path, std::vector<std::string> 
 {
   auto workspace = bazel_info(bazel_path, bazel_startup_options, "workspace");
   auto execution_root = bazel_info(bazel_path, bazel_startup_options, "execution_root");
+  auto output_base = bazel_info(bazel_path, bazel_startup_options, "output_base");
 
   if (workspace.empty()) {
     throw workspace_error();
   }
 
-  return bazel(bazel_path, std::move(bazel_startup_options), workspace, execution_root);
+  return bazel(bazel_path, std::move(bazel_startup_options), workspace, execution_root, output_base);
 }
 
 analysis::ActionGraphContainer
@@ -120,11 +121,13 @@ bazel::aquery(std::string const& query,
 bazel::bazel(std::filesystem::path bazel_commands,
              std::vector<std::string> bazel_startup_options,
              std::filesystem::path workspace_path,
-             std::filesystem::path execution_root)
+             std::filesystem::path execution_root,
+             std::filesystem::path output_base)
   : bazel_command_(std::move(bazel_commands))
   , bazel_startup_options_(std::move(bazel_startup_options))
   , workspace_path_(std::move(workspace_path))
   , execution_root_(std::move(execution_root))
+  , output_base_(std::move(output_base))
 {
 }
 } // namespace bcc

--- a/bcc/bazel.hpp
+++ b/bcc/bazel.hpp
@@ -44,6 +44,9 @@ public:
   // Return the path to the execution root of bazel
   std::filesystem::path execution_root() const { return execution_root_; };
 
+  // Return the path to the output base of bazel
+  std::filesystem::path output_base() const { return output_base_; };
+
   // Execute an `aquery` on the current workspace.
   analysis::ActionGraphContainer aquery(std::string const& query,
                                         std::vector<std::string> const& bazel_flags,
@@ -54,12 +57,14 @@ private:
   bazel(std::filesystem::path bazel_command,
         std::vector<std::string> bazel_startup_options,
         std::filesystem::path workspace,
-        std::filesystem::path execution_root);
+        std::filesystem::path execution_root,
+        std::filesystem::path output_base);
 
 private:
   std::filesystem::path bazel_command_;
   std::vector<std::string> bazel_startup_options_;
   std::filesystem::path workspace_path_;
   std::filesystem::path execution_root_;
+  std::filesystem::path output_base_;
 };
 } // namespace bcc

--- a/bcc/compile_commands.cpp
+++ b/bcc/compile_commands.cpp
@@ -146,7 +146,7 @@ compile_commands_builder::build(analysis::ActionGraphContainer const& action_gra
           }
         }
         auto obj = boost::json::object();
-        obj.insert(boost::json::object::value_type{ "directory", execution_root_.string() });
+        obj.insert(boost::json::object::value_type{ "directory", workspace_path_.string() });
         if (command_) {
           obj.insert(boost::json::object::value_type{ "command", join_arguments(args) });
         } else {

--- a/bcc/main.cpp
+++ b/bcc/main.cpp
@@ -148,6 +148,12 @@ main(int argc, char** argv)
         throw file_error("write", options.output_path);
       }
     }
+
+    auto external_symlink = bazel.workspace_path() / "external";
+    if (!std::filesystem::exists(external_symlink) &&
+        std::filesystem::symlink_status(external_symlink).type() == std::filesystem::file_type::not_found) {
+      std::filesystem::create_directory_symlink(bazel.output_base() / "external", external_symlink);
+    }
   } catch (std::exception const& ex) {
     std::cerr << "fatal error: " << ex.what() << std::endl;
     return 1;


### PR DESCRIPTION
This might be controversial--if so, maybe it can be enabled by a flag. Not that this indicates correctness, but this is what Hedron's does and has worked for my team.

I see two issues with using the execution root as the directory.
* clangd (as configured in my VS code, at least) doesn't automatically index all files, because the directory doesn't match the workspace. They still get indexed when opened, so this is possibly a minor bug in clangd or vs code, but the workspace really is the original location of the source files. Using the workspace path allows all source files to get indexed in the background.
* externals get referenced relative to `external`, for example `-isystem external/catch2+/src`. `$(execution_root)/external` doesn't seem to always have all of your externals, I'm not totally sure what determines this. `$(output_base)/external` does always have them, and this is what the `external` symlink in the workspace points to. This fixed some missing header errors for me.