### PR TITLE
Pass Bazel flags to `bazel info`

### DIFF
--- a/bcc/bazel.cpp
+++ b/bcc/bazel.cpp
@@ -22,10 +22,12 @@ namespace {
 std::filesystem::path
 bazel_info(std::filesystem::path const& bazel_path,
            std::vector<std::string> const& bazel_startup_options,
+           std::vector<std::string> const& bazel_flags,
            std::string const& location)
 {
   std::vector<std::string> args(std::begin(bazel_startup_options), std::end(bazel_startup_options));
   args.push_back("info");
+  args.insert(args.end(), bazel_flags.begin(), bazel_flags.end());
   args.push_back(location);
   boost::process::ipstream outs;
   boost::process::ipstream errs;
@@ -74,10 +76,12 @@ proto_error::proto_error(std::string const& what)
 }
 
 bazel
-bazel::create(std::filesystem::path const& bazel_path, std::vector<std::string> bazel_startup_options)
+bazel::create(std::filesystem::path const& bazel_path,
+              std::vector<std::string> bazel_startup_options,
+              std::vector<std::string> bazel_flags)
 {
-  auto workspace = bazel_info(bazel_path, bazel_startup_options, "workspace");
-  auto execution_root = bazel_info(bazel_path, bazel_startup_options, "execution_root");
+  auto workspace = bazel_info(bazel_path, bazel_startup_options, bazel_flags, "workspace");
+  auto execution_root = bazel_info(bazel_path, bazel_startup_options, bazel_flags, "execution_root");
 
   if (workspace.empty()) {
     throw workspace_error();

--- a/bcc/bazel.hpp
+++ b/bcc/bazel.hpp
@@ -33,7 +33,9 @@ public:
 class bazel
 {
 public:
-  static bazel create(std::filesystem::path const& bazel_path, std::vector<std::string> bazel_startup_options);
+  static bazel create(std::filesystem::path const& bazel_path,
+                      std::vector<std::string> bazel_startup_options,
+                      std::vector<std::string> bazel_flags);
 
   // Path of the `bazel` executable.
   std::filesystem::path command_path() const { return bazel_command_; };

--- a/bcc/main.cpp
+++ b/bcc/main.cpp
@@ -72,7 +72,7 @@ main(int argc, char** argv)
       return 1;
     }
 
-    auto const bazel = bcc::bazel::create(options.bazel_command, options.bazel_startup_options);
+    auto const bazel = bcc::bazel::create(options.bazel_command, options.bazel_startup_options, options.bazel_flags);
 
     if (options.write_rc_file) {
       if (!options.rcpath.has_value()) {


### PR DESCRIPTION
In some cases, the Bazel flags are necessary for `bazel info` to succeed. For example, if the project depends on a version of a package which only exists in a custom BCR registry specified by `--registry`, `bazel info execution_root` will fail unless the `--registry` flag is specified. Address this by passing the Bazel flags through in addition to the startup options.