### PR TITLE
Enable test for win32

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -13,6 +13,13 @@ build --enable_runfiles
 build:cl --cxxopt=/std:c++17
 build:gnu --cxxopt=-std=c++17
 
+# Disable Boost's MSVC auto-link pragma; Bazel handles linking explicitly.
+build:cl --cxxopt=-DBOOST_ALL_NO_LIB
+
+# io_bazel's generated protobufs contain a field named 'environ', which MSVC CRT
+# turns into a macro. Suppress POSIX CRT name aliases only for io_bazel source files.
+build:cl --per_file_copt=.*io_bazel.*@/D_CRT_DECLARE_NONSTDC_NAMES=0
+
 build:gnu --copt=-pedantic
 build:gnu --copt=-Wall
 build:gnu --copt=-Wextra

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -50,7 +50,7 @@ filegroup(
     srcs = select({
         "@platforms//os:linux": ["@pandoc_linux_x86_64//:pandoc"],
         "@platforms//os:macos": [":pandoc_macos"],
-        "@platforms//os:windows": ["@pandoc_windowss_x86_64//:pandoc"],
+        "@platforms//os:windows": ["@pandoc_windows_x86_64//:pandoc"],
     }),
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,7 +14,7 @@ bazel_dep(name = "boost.program_options", version = "1.87.0")
 bazel_dep(name = "googleapis", version = "0.0.0-20250826-a92cee39")
 bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "protobuf", version = "32.1", repo_name = "com_google_protobuf")
-bazel_dep(name = "rules_apple", version = "4.2.0", repo_name = "build_bazel_rules_apple")
+bazel_dep(name = "rules_apple", version = "4.5.3", repo_name = "build_bazel_rules_apple")
 bazel_dep(name = "rules_cc", version = "0.2.9")
 bazel_dep(name = "rules_java", version = "8.16.1")
 bazel_dep(name = "rules_pkg", version = "1.1.0")
@@ -69,7 +69,7 @@ http_archive(
 
 http_archive(
     name = "pandoc_windows_x86_64",
-    build_file = "//bazel:pandoc.BUILD",
+    build_file = "//bazel:pandoc_windows.BUILD",
     integrity = "sha256-BnMre5bTuZ9xG6G/JPKJ/LW8lWEZK9wb2VFMF8iqLCA=",
     strip_prefix = "pandoc-3.6",
     urls = ["https://github.com/jgm/pandoc/releases/download/3.6/pandoc-3.6-windows-x86_64.zip"],

--- a/bazel/pandoc_windows.BUILD
+++ b/bazel/pandoc_windows.BUILD
@@ -1,0 +1,7 @@
+filegroup(
+    name = "pandoc",
+    srcs = [
+        "pandoc.exe",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/bcc/BUILD.bazel
+++ b/bcc/BUILD.bazel
@@ -51,11 +51,17 @@ cc_proto_library(
 )
 
 cc_library(
+    name = "detail_analysis_v2",
+    hdrs = ["detail/analysis_v2.hpp"],
+    deps = [":analysis"],
+)
+
+cc_library(
     name = "artifacts",
     srcs = ["artifacts.cpp"],
     hdrs = ["artifacts.hpp"],
     deps = [
-        ":analysis",
+        ":detail_analysis_v2",
         ":path_fragments",
     ],
 )
@@ -66,7 +72,7 @@ cc_library(
     hdrs = ["bazel.hpp"],
     defines = ["BOOST_PROCESS_USE_STD_FS=1"],
     deps = [
-        ":analysis",
+        ":detail_analysis_v2",
         "@boost.json",
         "@boost.process",
     ],
@@ -77,7 +83,7 @@ cc_library(
     srcs = ["compile_commands.cpp"],
     hdrs = ["compile_commands.hpp"],
     deps = [
-        ":analysis",
+        ":detail_analysis_v2",
         ":artifacts",
         ":dep_set_of_files",
         ":path_fragments",
@@ -102,7 +108,7 @@ cc_library(
     srcs = ["dep_set_of_files.cpp"],
     hdrs = ["dep_set_of_files.hpp"],
     deps = [
-        ":analysis",
+        ":detail_analysis_v2",
         ":artifacts",
         "@boost.core",
     ],
@@ -127,7 +133,7 @@ cc_library(
     srcs = ["path_fragments.cpp"],
     hdrs = ["path_fragments.hpp"],
     deps = [
-        ":analysis",
+        ":detail_analysis_v2",
     ],
 )
 

--- a/bcc/artifacts.hpp
+++ b/bcc/artifacts.hpp
@@ -3,7 +3,7 @@
 #include <cstdint>
 #include <string>
 
-#include "src/main/protobuf/analysis_v2.pb.h"
+#include "bcc/detail/analysis_v2.hpp"
 
 #include "bcc/path_fragments.hpp"
 

--- a/bcc/bazel.hpp
+++ b/bcc/bazel.hpp
@@ -7,7 +7,7 @@
 
 #include <boost/json.hpp>
 
-#include "src/main/protobuf/analysis_v2.pb.h"
+#include "bcc/detail/analysis_v2.hpp"
 
 namespace bcc {
 

--- a/bcc/compile_commands.hpp
+++ b/bcc/compile_commands.hpp
@@ -8,7 +8,7 @@
 
 #include <boost/json/value.hpp>
 
-#include "src/main/protobuf/analysis_v2.pb.h"
+#include "bcc/detail/analysis_v2.hpp"
 
 namespace bcc {
 

--- a/bcc/dep_set_of_files.hpp
+++ b/bcc/dep_set_of_files.hpp
@@ -8,7 +8,7 @@
 
 #include <boost/core/span.hpp>
 
-#include "src/main/protobuf/analysis_v2.pb.h"
+#include "bcc/detail/analysis_v2.hpp"
 
 #include "bcc/artifacts.hpp"
 

--- a/bcc/detail/analysis_v2.hpp
+++ b/bcc/detail/analysis_v2.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+// MSVC CRT defines environ as a macro (*__p__environ()), which conflicts with
+// the 'environ' field accessor generated for RepositoryRuleInfo in
+// stardoc_output.pb.h (included transitively via analysis_v2.pb.h).
+#ifdef environ
+#undef environ
+#endif
+#include "src/main/protobuf/analysis_v2.pb.h"

--- a/bcc/path_fragments.hpp
+++ b/bcc/path_fragments.hpp
@@ -4,7 +4,7 @@
 #include <filesystem>
 #include <unordered_map>
 
-#include "src/main/protobuf/analysis_v2.pb.h"
+#include "bcc/detail/analysis_v2.hpp"
 
 namespace bcc {
 ///  Path fragment table to build full path from workspace.

--- a/clangd-wrapper/main.cpp
+++ b/clangd-wrapper/main.cpp
@@ -124,7 +124,7 @@ main(int argc, char* argv[])
   fs::path const workspace_dir = get_workspace_dir(clangd_args);
 
   std::optional<std::string> const execution_root =
-    get_bazel_execution_root(bazel_path, workspace_dir, bazel_startup_options);
+    get_bazel_execution_root(bazel_path, workspace_dir.string(), bazel_startup_options);
   if (execution_root) {
     clangd_args.push_back("--path-mappings=" + workspace_dir.string() + "=" + execution_root.value());
   }

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -18,5 +18,5 @@ cc_test(
 cc_binary(
     name = "bazel-mock",
     srcs = ["bazel_mock.cpp"],
-    deps = ["//bcc:analysis"],
+    deps = ["//bcc:detail_analysis_v2"],
 )

--- a/tests/bazel_mock.cpp
+++ b/tests/bazel_mock.cpp
@@ -5,9 +5,14 @@
 #include <string_view>
 #include <vector>
 
+#ifdef _WIN32
+#include <fcntl.h>
+#include <io.h>
+#endif
+
 #include <google/protobuf/text_format.h>
 
-#include "src/main/protobuf/analysis_v2.pb.h"
+#include "bcc/detail/analysis_v2.hpp"
 
 namespace {
 char const* const aquery_textproto = R"(
@@ -221,6 +226,9 @@ main(int argc, char** argv)
   } else if (aquery_iter != std::end(arguments)) {
     analysis::ActionGraphContainer agc;
     google::protobuf::TextFormat::ParseFromString(aquery_textproto, &agc);
+#ifdef _WIN32
+    _setmode(_fileno(stdout), _O_BINARY);
+#endif
     agc.SerializePartialToOstream(&std::cout);
     return 0;
   } else {

--- a/tests/self_test.cpp
+++ b/tests/self_test.cpp
@@ -58,13 +58,11 @@ run(std::filesystem::path const& commmand, std::vector<std::string_view> args)
 
 TEST(self_test, run)
 {
-  // TODO: Fix tests for Windows (I do not have Windows)
-#ifndef _WIN32
   std::string error;
   std::unique_ptr<Runfiles> runfiles(Runfiles::CreateForTest(&error));
   ASSERT_THAT(runfiles, NotNull()) << error;
 
-  auto const bcc_path = runfiles->Rlocation("bazel-compile-commands/bcc/bazel-compile-commands") + exe_suffix();
+  auto const bcc_path = runfiles->Rlocation("bazel-compile-commands/bcc/bazel-compile-commands");
   ASSERT_THAT(bcc_path, Not(IsEmpty())) << bcc_path;
   ASSERT_THAT(std::filesystem::exists(bcc_path), IsTrue()) << bcc_path;
 
@@ -101,7 +99,6 @@ TEST(self_test, run)
   for (auto const& sf : seen_files) {
     EXPECT_THAT(sf.second, IsTrue()) << sf.first;
   }
-#endif
 }
 
 } // namespace

--- a/tools/clang-format.ps1
+++ b/tools/clang-format.ps1
@@ -10,8 +10,8 @@
 #
 
 $files = Get-ChildItem -Directory |
-    Where-Object Name -notmatch '^(\.git|bazel-|third_party)' |
+    Where-Object Name -notmatch '^(\.|bazel-|third_party)' |
     ForEach-Object { Get-ChildItem -Path $_.FullName -Recurse -Include *.cpp, *.hpp } |
     Select-Object -ExpandProperty FullName
 
-D:\work\clang\bin\clang-format --style=file --fallback-style=none @args @files
+clang-format --style=file --fallback-style=none @args @files

--- a/tools/clang-format.ps1
+++ b/tools/clang-format.ps1
@@ -1,0 +1,17 @@
+#!/usr/bin/env pwsh
+#
+# Run clang-format on all source files.
+#
+# Usage:
+#
+#     ./tools/clang-format.ps1 -i
+#
+#     ./tools/clang-format.ps1 --dry-run -Werror
+#
+
+$files = Get-ChildItem -Directory |
+    Where-Object Name -notmatch '^(\.git|bazel-|third_party)' |
+    ForEach-Object { Get-ChildItem -Path $_.FullName -Recurse -Include *.cpp, *.hpp } |
+    Select-Object -ExpandProperty FullName
+
+D:\work\clang\bin\clang-format --style=file --fallback-style=none @args @files


### PR DESCRIPTION
# Description

The proposed changes enable `bazel build //...` under windows again. I tried to address each issue in a separate commit.

The most critical one is an issue with an included header, which is generated out of the main bazel repository. There a field is named "environ", which for msvc is a predefined macro, resulting in issues when using a default msvc toolchain. I tried to fix it by undefining the macro and also by defining -D_CRT_DECLARE_NONSTDC_NAMES=0 for the io_bazel files. We cannot use the define globally, since this suppresses the POSIX-compatiblity which is is needed in googletest. We could also patch the protobuff file to give the field a different name, but I thought the current approach might be better.

# Related issue
Part of #89
